### PR TITLE
Enable Sauce EU data centre.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ This code is provided on an "AS-IS” basis without warranty of any kind, either
     $ export SAUCE_USERNAME=<your Sauce Labs username>
     $ export SAUCE_ACCESS_KEY=<your Sauce Labs access key>
     ```
+    * If you are using the EU data center:
+    ```
+    $ export SAUCE_DATA_CENTER=EU
+    ```
 
 3. Project Dependencies
 	* Install packages (Use sudo if necessary)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -11,10 +11,8 @@ Before do |scenario|
     browser = options.delete(:browser_name).to_sym
     caps = Selenium::WebDriver::Remote::Capabilities.send(browser, options)
 
-    url = 'https://ondemand.saucelabs.com:443/wd/hub'
-
     Capybara::Selenium::Driver.new(app, browser: :remote,
-                                        url: url,
+                                        url: sauce_url,
                                         desired_capabilities: caps)
   end
   Capybara.current_driver = :sauce
@@ -22,6 +20,7 @@ end
 
 After do |scenario|
   session_id = Capybara.current_session.driver.browser.session_id
+  SauceWhisk.data_center = "#{sauce_data_center}_VDC".to_sym
   SauceWhisk::Jobs.change_status(session_id, scenario.passed?)
   Capybara.current_session.quit
 end
@@ -81,6 +80,17 @@ def sauce_oss(name)
    username: ENV['SAUCE_USERNAME'],
    access_key: ENV['SAUCE_ACCESS_KEY'],
    selenium_version: '3.141.59'}
+end
+
+def sauce_data_center
+  ENV.fetch('SAUCE_DATA_CENTER', 'US')
+end
+
+def sauce_url
+  {
+    'US' => 'https://ondemand.saucelabs.com:443/wd/hub',
+    'EU' => 'https://ondemand.eu-central-1.saucelabs.com/wd/hub'
+  }.fetch(sauce_data_center)
 end
 
 #


### PR DESCRIPTION
- Can be set to EU with `export SAUCE_DATA_CENTER=EU`
- Default is still US to avoid changes for US customers.
- Documentation updated.